### PR TITLE
Implement Basic Emoji Functionality 😀

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -4,11 +4,13 @@ import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import ToolbarPlugin from "./ToolbarPlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { EmoticonNode } from "./EmoticonNode";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import { ListItemNode, ListNode } from "@lexical/list";
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import EmoticonPlugin from "./EmoticonPlugin";
 
 function Placeholder() {
   return <div className="editor-placeholder">Enter some rich text...</div>;
@@ -29,6 +31,7 @@ const editorConfig = {
     QuoteNode,
     CodeNode,
     CodeHighlightNode,
+    EmoticonNode,
     TableNode,
     TableCellNode,
     TableRowNode,
@@ -49,6 +52,7 @@ export default function Editor({ onChange }) {
           />
           {/* Insert Plugins Here (see https://codesandbox.io/s/lexical-rich-text-example-forked-x8rgfk?file=/src/Editor.js) */}
           <OnChangePlugin onChange={onChange} />
+          <EmoticonPlugin />
         </div>
       </div>
     </LexicalComposer>

--- a/src/EmoticonNode.js
+++ b/src/EmoticonNode.js
@@ -1,0 +1,32 @@
+import { TextNode } from "lexical";
+
+export class EmoticonNode extends TextNode {
+  __className: string;
+
+  static getType(): string {
+    return "emoticon";
+  }
+
+  static clone(node) {
+    return new EmoticonNode(node.__className, node.__text, node.__key);
+  }
+
+  constructor(className, text, key) {
+    super(text, key);
+    this.__className = className;
+  }
+
+  createDOM(config) {
+    const dom = super.createDOM(config);
+    dom.className = this.__className;
+    return dom;
+  }
+}
+
+export function $isEmoticonNode(node) {
+  return node instanceof EmoticonNode;
+}
+
+export function $createEmoticonNode(className, emoticonText) {
+  return new EmoticonNode(className, emoticonText).setMode("token");
+}

--- a/src/EmoticonPlugin.js
+++ b/src/EmoticonPlugin.js
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { $createEmoticonNode } from "./EmoticonNode";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { TextNode } from "lexical";
+
+const colors = new Map([
+  [":g:", ["green circle", "🟢"]],
+  [":y", ["yellow circle", "🟡"]],
+  [":r", ["red circle", "🔴"]],
+]);
+
+function emoticonTransform(node) {
+  const textContent = node.getTextContent();
+  if (textContent === ":)") {
+    node.replace($createEmoticonNode("", "😀"));
+  }
+}
+
+function useEmoticons(editor) {
+  useEffect(() => {
+    const removeTransform = editor.registerNodeTransform(
+      TextNode,
+      emoticonTransform
+    );
+    return () => {
+      removeTransform();
+    };
+  }, [editor]);
+}
+
+export default function EmoticonPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEmoticons(editor);
+  return null;
+}


### PR DESCRIPTION
Basic emoji functionality according to [Lexical docs](https://github.com/facebook/lexical/blob/main/examples/emoticons.md). 

Typing `:)` into the editor now converts to the emoji 😀. 

However, `:)` **MUST** be the very first thing user types into the editor. The editor won't convert `:)` otherwise.